### PR TITLE
adding new requirement "lxml" needed by "bs4"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ MarkupSafe==1.0
 packaging==16.8
 six==1.10.0
 Werkzeug==0.12.1
+lxml==4.2.1


### PR DESCRIPTION
I've got an error with executing your script :

`Traceback (most recent call last):
  File "./builder.py", line 134, in <module>
    main(args)
  File "./builder.py", line 114, in main
    download_page(url, 'page.html')
  File "./builder.py", line 49, in download_page
    soup = BeautifulSoup(html, 'lxml')
  File "/usr/lib/python2.7/site-packages/bs4/__init__.py", line 165, in __init__
    % ",".join(features))
bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: lxml. Do you need to install a parser library?
`

With installing "lxml" it works.